### PR TITLE
Avoid mutable default arguments and enforce utf-8

### DIFF
--- a/lib/gcv2hocr.py
+++ b/lib/gcv2hocr.py
@@ -41,9 +41,13 @@ class GCVAnnotation:
                  baseline="0 -5",
                  page_height=None,
                  page_width=None,
-                 content=[],
+                 content=None,
                  box=None,
                  title=''):
+        if content==None:
+            self.content = []
+        else:
+            self.content = content
         self.title = title
         self.htmlid = htmlid
         self.baseline = baseline
@@ -51,7 +55,6 @@ class GCVAnnotation:
         self.page_width = page_width
         self.lang = lang
         self.ocr_class = ocr_class
-        self.content = content
         self.x0 = box[0]['x']
         self.y0 = box[0]['y']
         self.x1 = box[2]['x']
@@ -158,7 +161,7 @@ if __name__ == '__main__':
         help="Image height. Automatically detected unless specified")
     args = parser.parse_args()
 
-    instream = sys.stdin if args.gcv_file is '-' else open(args.gcv_file, 'r')
+    instream = sys.stdin if args.gcv_file is '-' else open(args.gcv_file, 'r', encoding='utf-8')
     resp = json.load(instream)
     if hasattr(resp, 'responses'): resp = ['responses'][0]
 


### PR DESCRIPTION
Using mutable default arguments produces errors when creating multiple instances of the class.

Encoding="utf-8" should be enforced, otherwise the script fails in environments with a non-standard command line locale.
Google outputs results in utf-8.
The UTF-8 encoding of the resulting file was already specified in the <meta http-equiv="Content-Type" content="text/html;charset=utf-8" /> tag. Hence, Python 3 should always output a utf-8 file.